### PR TITLE
Run log PR workflow on `pull_request_target` event (GEA-11261)

### DIFF
--- a/.github/workflows/log_pull_request.yml
+++ b/.github/workflows/log_pull_request.yml
@@ -1,6 +1,6 @@
 name: "Log Pull Requests"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
   test:


### PR DESCRIPTION
The "Log Pull Requests" workflow depends on GitHub secrets which are not accessible to pull requests from forked repositories. This causes the workflow to fail on any such pull request. This patch fixes this issue by updating the trigger event to `pull_request_target`, which provides access to secrets even in the case of forked repositories at the "cost" of not actually checking out code from the forked repository, which is perfectly fine for this particular workflow.

Refer: <https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target>