### PR TITLE
Update example to use `pull_request_target` (GEA-11330)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Minimal example
 ```yml
 name: "Log Pull Request"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
   test:


### PR DESCRIPTION
I missed this in ed9ac16.